### PR TITLE
Slight update to the coding to help resolve reported issue #21

### DIFF
--- a/sse.pl
+++ b/sse.pl
@@ -647,7 +647,7 @@ sub email_valiases {
         if ( $doc_root =~ m/DocumentRoot\s(\/.+?\/.+?\/)/ ) {
             print_warning(
                 "[WARN] * E-mail filter files exist for mailbox $email.\n")
-              if -e "$1\/etc\/$maildomain\/$user\/filter";
+              if -e -s "$1\/etc\/$maildomain\/$user\/filter";
         }
     }
 


### PR DESCRIPTION
Was able to find and replicate the issue that was reported in https://github.com/CpanelInc/tech-SSE/issues/21 

It seems that Perl is able to easily test for a nonzero file with the -s flag. After updating this code I was able to confirm that the message shows up once a filter has been added. When it is 0 bytes, the message no longer appears. 

This should be able to go through and lower the amount of red herrings that techs or clients may be running into when attempting to troubleshoot. 